### PR TITLE
feat(log): added github actions properties from event file

### DIFF
--- a/.github/workflows/event.json
+++ b/.github/workflows/event.json
@@ -1,0 +1,19 @@
+{
+    "pull_request": {
+        "head": {
+            "ref": "test-ref",
+            "sha": "test-sha"
+        },
+        "base": {
+            "ref": "test-ref",
+            "sha": "test-sha"
+        },
+        "issue_url": "test-issue",
+        "html_url": "test-html",
+        "title": "test-title"
+    },
+    "sender": {
+        "avatar_url": "test-avatar",
+        "html_url": "test-html"
+    }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: rm /home/runner/work/_temp/_github_workflow/event.json
-      - run: cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
+      - run: |
+          rm /home/runner/work/_temp/_github_workflow/event.json
+          cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
+          cat /home/runner/work/_temp/_github_workflow/event.json
       - run: npm ci
-      - run: cat /home/runner/work/_temp/_github_workflow/event.json
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,5 @@ jobs:
           node-version: 16
       - run: cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
       - run: npm ci
+      - run: cat /home/runner/work/_temp/_github_workflow/event.json
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,15 @@ jobs:
       - run: npm test
       # - if: github.ref == 'refs/heads/master'
         # run: npm run semantic-release
+  gha:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy event file
+      - run: cp ./event.json /home/runner/work/_temp/_github_workflow/event.json
+
+      - name: Run gha e2e
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
           rm /home/runner/work/_temp/_github_workflow/event.json
           cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
           cat /home/runner/work/_temp/_github_workflow/event.json
-      - run: npm run gha-e2e
+          npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: cp ./event.json /home/runner/work/_temp/_github_workflow/event.json
+      - run: cp event.json /home/runner/work/_temp/_github_workflow/event.json
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,5 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: |
-          rm /home/runner/work/_temp/_github_workflow/event.json
           cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
-          cat /home/runner/work/_temp/_github_workflow/event.json
           npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: cp event.json /home/runner/work/_temp/_github_workflow/event.json
+      - run: cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: npm ci
       - run: |
           rm /home/runner/work/_temp/_github_workflow/event.json
           cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
           cat /home/runner/work/_temp/_github_workflow/event.json
-      - run: npm ci
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,10 @@ jobs:
   gha:
     runs-on: ubuntu-latest
     steps:
-      - name: Copy event file
-      - run: cp ./event.json /home/runner/work/_temp/_github_workflow/event.json
-
       - name: Run gha e2e
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: cp ./event.json /home/runner/work/_temp/_github_workflow/event.json
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           node-version: 16
       - run: cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
+      - run: npm ci
       - run: npm run gha-e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: rm /home/runner/work/_temp/_github_workflow/event.json
       - run: cp .github/workflows/event.json /home/runner/work/_temp/_github_workflow/event.json
       - run: npm ci
       - run: cat /home/runner/work/_temp/_github_workflow/event.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "prettier-standard": "8.0.1",
         "semantic-release": "17.2.3",
         "simple-commit-message": "4.1.3",
+        "sinon": "17.0.1",
         "snap-shot-it": "7.9.3",
         "standard": "13.1.0",
         "stub-spawn-once": "2.3.0"
@@ -948,6 +949,50 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/@sheerun/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "integrity": "sha512-aalIRUtcR6nPf50kEwnYvepSJIdpulrbMeeNMwiOmFgBg4MgScCmlI7SqOmsGJNqaH65+benoqt0H4N0RR2Okg==",
+      "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -7349,6 +7394,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -7647,6 +7698,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.ismatch": {
@@ -8961,6 +9018,46 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node_modules/nise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
     },
     "node_modules/node-emoji": {
       "version": "1.10.0",
@@ -14377,6 +14474,21 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -18162,6 +18274,54 @@
         "node": ">=4"
       }
     },
+    "node_modules/sinon": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.5",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -19444,6 +19604,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -20804,6 +20973,52 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/@sheerun/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "integrity": "sha512-aalIRUtcR6nPf50kEwnYvepSJIdpulrbMeeNMwiOmFgBg4MgScCmlI7SqOmsGJNqaH65+benoqt0H4N0RR2Okg==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -26056,6 +26271,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -26318,6 +26539,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -27393,6 +27620,50 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^3.0.0"
+          },
+          "dependencies": {
+            "@sinonjs/commons": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+              "dev": true,
+              "requires": {
+                "type-detect": "4.0.8"
+              }
+            }
+          }
+        }
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -31578,6 +31849,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -34615,6 +34903,43 @@
         }
       }
     },
+    "sinon": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.5",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -35633,6 +35958,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "prettier-standard": "8.0.1",
     "semantic-release": "17.2.3",
     "simple-commit-message": "4.1.3",
+    "sinon": "17.0.1",
     "snap-shot-it": "7.9.3",
     "standard": "13.1.0",
     "stub-spawn-once": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
     "test": "npm run unit",
     "unit": "mocha src/*-spec.js",
+    "gha-e2e": "mocha src/utils-e2e.js",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
   },
   "release": {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,11 @@ const {
   getTimestamp,
   getRemoteOrigin
 } = require('./git-api')
-const { getBranch, getCommitInfoFromEnvironment } = require('./utils')
+const {
+  getBranch,
+  getCommitInfoFromEnvironment,
+  getGhaEventData
+} = require('./utils')
 const Promise = require('bluebird')
 const { mergeWith, or } = require('ramda')
 
@@ -26,7 +30,11 @@ function commitInfo (folder) {
     author: getAuthor(folder),
     sha: getSha(folder),
     timestamp: getTimestamp(folder),
-    remote: getRemoteOrigin(folder)
+    remote: getRemoteOrigin(folder),
+    ghaEventData: getGhaEventData(
+      process.env.GITHUB_EVENT_PATH,
+      process.env.GITHUB_ACTIONS
+    )
   }).then(info => {
     const envVariables = getCommitInfoFromEnvironment()
     debug('git commit: %o', info)

--- a/src/utils-e2e.js
+++ b/src/utils-e2e.js
@@ -44,9 +44,6 @@ describe('utils', () => {
         process.env.GITHUB_EVENT_PATH,
         process.env.GITHUB_ACTIONS
       )
-      console.log('EVE::', eventData)
-      console.log('PATH::', process.env.GITHUB_EVENT_PATH)
-      console.log('ACT::', process.env.GITHUB_ACTIONS)
 
       la(JSON.stringify(eventData) === JSON.stringify(eventResult), eventData)
     })

--- a/src/utils-e2e.js
+++ b/src/utils-e2e.js
@@ -26,7 +26,7 @@ describe('utils', () => {
 
   const eventResult = {
     headRef: event.pull_request.head.ref,
-    headhSha: event.pull_request.head.sha,
+    headSha: event.pull_request.head.sha,
     baseRef: event.pull_request.base.ref,
     baseSha: event.pull_request.base.sha,
     issueUrl: event.pull_request.issue_url,

--- a/src/utils-e2e.js
+++ b/src/utils-e2e.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const la = require('lazy-ass')
+
+/* eslint-env mocha */
+describe('utils', () => {
+  const event = {
+    pull_request: {
+      head: {
+        ref: 'test-ref',
+        sha: 'test-sha'
+      },
+      base: {
+        ref: 'test-ref',
+        sha: 'test-sha'
+      },
+      issue_url: 'test-issue',
+      html_url: 'test-html',
+      title: 'test-title'
+    },
+    sender: {
+      avatar_url: 'test-avatar',
+      html_url: 'test-html'
+    }
+  }
+
+  const eventResult = {
+    headRef: event.pull_request.head.ref,
+    headhSha: event.pull_request.head.sha,
+    baseRef: event.pull_request.base.ref,
+    baseSha: event.pull_request.base.sha,
+    issueUrl: event.pull_request.issue_url,
+    htmlUrl: event.pull_request.html_url,
+    prTitle: event.pull_request.title,
+    senderAvatarUrl: event.sender.avatar_url,
+    senderHtmlUrl: event.sender.html_url
+  }
+
+  describe('E2E gha event data', () => {
+    const { getGhaEventData } = require('./utils')
+
+    it('returns event data if file path and gha env are truthy', () => {
+      const eventData = getGhaEventData(
+        process.env.GITHUB_EVENT_PATH,
+        process.env.GITHUB_ACTIONS
+      )
+
+      la(JSON.stringify(eventData) === JSON.stringify(eventResult), eventData)
+    })
+  })
+})

--- a/src/utils-e2e.js
+++ b/src/utils-e2e.js
@@ -44,6 +44,9 @@ describe('utils', () => {
         process.env.GITHUB_EVENT_PATH,
         process.env.GITHUB_ACTIONS
       )
+      console.log('EVE::', eventData)
+      console.log('PATH::', process.env.GITHUB_EVENT_PATH)
+      console.log('ACT::', process.env.GITHUB_ACTIONS)
 
       la(JSON.stringify(eventData) === JSON.stringify(eventResult), eventData)
     })

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -3,6 +3,8 @@
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const { mergeWith, or } = require('ramda')
+const sinon = require('sinon')
+const fs = require('fs')
 
 /* eslint-env mocha */
 describe('utils', () => {
@@ -56,6 +58,71 @@ describe('utils', () => {
     it('finds nothing', () => {
       const found = firstFoundValue(['z', 'x'], env)
       la(found === null, found)
+    })
+  })
+
+  describe('getGhaEventData', () => {
+    let readFileStub
+    const { getGhaEventData } = require('./utils')
+
+    const event = {
+      pull_request: {
+        head: {
+          ref: 'test-ref',
+          sha: 'test-sha'
+        },
+        base: {
+          ref: 'test-ref',
+          sha: 'test-sha'
+        },
+        issue_url: 'test-issue',
+        html_url: 'test-html',
+        title: 'test-title'
+      },
+      sender: {
+        avatar_url: 'test-avatar',
+        html_url: 'test-html'
+      }
+    }
+
+    const eventResult = {
+      headRef: event.pull_request.head.ref,
+      headhSha: event.pull_request.head.sha,
+      baseRef: event.pull_request.base.ref,
+      baseSha: event.pull_request.base.sha,
+      issueUrl: event.pull_request.issue_url,
+      htmlUrl: event.pull_request.html_url,
+      prTitle: event.pull_request.title,
+      senderAvatarUrl: event.sender.avatar_url,
+      senderHtmlUrl: event.sender.html_url
+    }
+
+    beforeEach(() => {
+      readFileStub = sinon
+        .stub(fs, 'readFileSync')
+        .returns(JSON.stringify(event))
+    })
+
+    afterEach(() => {
+      readFileStub.restore()
+    })
+
+    it('returns event data if file path and gha env are truthy', () => {
+      const eventData = getGhaEventData('test-path', 'true')
+
+      la(JSON.stringify(eventData) === JSON.stringify(eventResult), eventData)
+    })
+
+    it('returns empty event data if file path is falsy', () => {
+      const eventData = getGhaEventData(undefined, 'true')
+
+      la(eventData === undefined, eventData)
+    })
+
+    it('returns empty event data if gha env variable is falsy', () => {
+      const eventData = getGhaEventData('test-path', undefined)
+
+      la(eventData === undefined, eventData)
     })
   })
 })

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -30,7 +30,7 @@ describe('utils', () => {
 
   const eventResult = {
     headRef: event.pull_request.head.ref,
-    headhSha: event.pull_request.head.sha,
+    headSha: event.pull_request.head.sha,
     baseRef: event.pull_request.base.ref,
     baseSha: event.pull_request.base.sha,
     issueUrl: event.pull_request.issue_url,

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -8,6 +8,38 @@ const fs = require('fs')
 
 /* eslint-env mocha */
 describe('utils', () => {
+  const event = {
+    pull_request: {
+      head: {
+        ref: 'test-ref',
+        sha: 'test-sha'
+      },
+      base: {
+        ref: 'test-ref',
+        sha: 'test-sha'
+      },
+      issue_url: 'test-issue',
+      html_url: 'test-html',
+      title: 'test-title'
+    },
+    sender: {
+      avatar_url: 'test-avatar',
+      html_url: 'test-html'
+    }
+  }
+
+  const eventResult = {
+    headRef: event.pull_request.head.ref,
+    headhSha: event.pull_request.head.sha,
+    baseRef: event.pull_request.base.ref,
+    baseSha: event.pull_request.base.sha,
+    issueUrl: event.pull_request.issue_url,
+    htmlUrl: event.pull_request.html_url,
+    prTitle: event.pull_request.title,
+    senderAvatarUrl: event.sender.avatar_url,
+    senderHtmlUrl: event.sender.html_url
+  }
+
   describe('getFields', () => {
     const { getFields } = require('./utils')
 
@@ -64,38 +96,6 @@ describe('utils', () => {
   describe('getGhaEventData', () => {
     let readFileStub
     const { getGhaEventData } = require('./utils')
-
-    const event = {
-      pull_request: {
-        head: {
-          ref: 'test-ref',
-          sha: 'test-sha'
-        },
-        base: {
-          ref: 'test-ref',
-          sha: 'test-sha'
-        },
-        issue_url: 'test-issue',
-        html_url: 'test-html',
-        title: 'test-title'
-      },
-      sender: {
-        avatar_url: 'test-avatar',
-        html_url: 'test-html'
-      }
-    }
-
-    const eventResult = {
-      headRef: event.pull_request.head.ref,
-      headhSha: event.pull_request.head.sha,
-      baseRef: event.pull_request.base.ref,
-      baseSha: event.pull_request.base.sha,
-      issueUrl: event.pull_request.issue_url,
-      htmlUrl: event.pull_request.html_url,
-      prTitle: event.pull_request.title,
-      senderAvatarUrl: event.sender.avatar_url,
-      senderHtmlUrl: event.sender.html_url
-    }
 
     beforeEach(() => {
       readFileStub = sinon

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,6 +60,7 @@ function getGhaEventData (eventFilePath, isGha) {
   let eventData
   if (eventFilePath && isGha === 'true') {
     const data = JSON.parse(fs.readFileSync(eventFilePath))
+    console.log('DATA::', data)
     eventData = {
       headRef: data.pull_request.head.ref,
       headhSha: data.pull_request.head.sha,

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,9 @@ function getGhaEventData (eventFilePath, isGha) {
       return
     }
 
+    debug('Retreiving GitHub Actions data from %s', eventFilePath)
     const data = JSON.parse(fs.readFileSync(eventFilePath))
+
     return {
       headRef: data.pull_request.head.ref,
       headSha: data.pull_request.head.sha,
@@ -75,7 +77,7 @@ function getGhaEventData (eventFilePath, isGha) {
       senderHtmlUrl: data.sender.html_url
     }
   } catch (e) {
-    console.debug('[GHA Data Error]: ', e)
+    debug('Retreiving GitHub Actions data error: %s', e)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 const { getGitBranch } = require('./git-api')
 const debug = require('debug')('commit-info')
+const fs = require('fs')
 
 function firstFoundValue (keys, object = process.env) {
   const found = keys.find(key => {
@@ -49,9 +50,35 @@ function getFields () {
   return ['branch', 'message', 'email', 'author', 'sha', 'remote', 'timestamp']
 }
 
+/**
+ * Gets the event data in github actions environment
+ * @param {string} eventFilePath
+ * @param {string 'true' | 'false' | undefined} isGha
+ * @returns {headRef: string; headhSha: string; baseRef: string; baseSha: string; issueUrl: string; htmlUrl: string; prTitle: string; senderAvatarUrl: string; senderHtmlUrl: string;}
+ */
+function getGhaEventData (eventFilePath, isGha) {
+  let eventData
+  if (eventFilePath && isGha === 'true') {
+    const data = JSON.parse(fs.readFileSync(eventFilePath))
+    eventData = {
+      headRef: data.pull_request.head.ref,
+      headhSha: data.pull_request.head.sha,
+      baseRef: data.pull_request.base.ref,
+      baseSha: data.pull_request.base.sha,
+      issueUrl: data.pull_request.issue_url,
+      htmlUrl: data.pull_request.html_url,
+      prTitle: data.pull_request.title,
+      senderAvatarUrl: data.sender.avatar_url,
+      senderHtmlUrl: data.sender.html_url
+    }
+  }
+  return eventData
+}
+
 module.exports = {
   firstFoundValue,
   getBranch,
   getCommitInfoFromEnvironment,
-  getFields
+  getFields,
+  getGhaEventData
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,7 +60,6 @@ function getGhaEventData (eventFilePath, isGha) {
   let eventData
   if (eventFilePath && isGha === 'true') {
     const data = JSON.parse(fs.readFileSync(eventFilePath))
-    console.log('DATA::', data)
     eventData = {
       headRef: data.pull_request.head.ref,
       headhSha: data.pull_request.head.sha,

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,22 +57,22 @@ function getFields () {
  * @returns {headRef: string; headhSha: string; baseRef: string; baseSha: string; issueUrl: string; htmlUrl: string; prTitle: string; senderAvatarUrl: string; senderHtmlUrl: string;}
  */
 function getGhaEventData (eventFilePath, isGha) {
-  let eventData
-  if (eventFilePath && isGha === 'true') {
-    const data = JSON.parse(fs.readFileSync(eventFilePath))
-    eventData = {
-      headRef: data.pull_request.head.ref,
-      headhSha: data.pull_request.head.sha,
-      baseRef: data.pull_request.base.ref,
-      baseSha: data.pull_request.base.sha,
-      issueUrl: data.pull_request.issue_url,
-      htmlUrl: data.pull_request.html_url,
-      prTitle: data.pull_request.title,
-      senderAvatarUrl: data.sender.avatar_url,
-      senderHtmlUrl: data.sender.html_url
-    }
+  if (!eventFilePath || !isGha) {
+    return
   }
-  return eventData
+
+  const data = JSON.parse(fs.readFileSync(eventFilePath))
+  return {
+    headRef: data.pull_request.head.ref,
+    headhSha: data.pull_request.head.sha,
+    baseRef: data.pull_request.base.ref,
+    baseSha: data.pull_request.base.sha,
+    issueUrl: data.pull_request.issue_url,
+    htmlUrl: data.pull_request.html_url,
+    prTitle: data.pull_request.title,
+    senderAvatarUrl: data.sender.avatar_url,
+    senderHtmlUrl: data.sender.html_url
+  }
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ function getFields () {
  * Gets the event data in github actions environment
  * @param {string} eventFilePath
  * @param {string 'true' | 'false' | undefined} isGha
- * @returns {headRef: string; headhSha: string; baseRef: string; baseSha: string; issueUrl: string; htmlUrl: string; prTitle: string; senderAvatarUrl: string; senderHtmlUrl: string;}
+ * @returns {headRef: string; headSha: string; baseRef: string; baseSha: string; issueUrl: string; htmlUrl: string; prTitle: string; senderAvatarUrl: string; senderHtmlUrl: string;}
  */
 function getGhaEventData (eventFilePath, isGha) {
   try {
@@ -65,7 +65,7 @@ function getGhaEventData (eventFilePath, isGha) {
     const data = JSON.parse(fs.readFileSync(eventFilePath))
     return {
       headRef: data.pull_request.head.ref,
-      headhSha: data.pull_request.head.sha,
+      headSha: data.pull_request.head.sha,
       baseRef: data.pull_request.base.ref,
       baseSha: data.pull_request.base.sha,
       issueUrl: data.pull_request.issue_url,

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,21 +57,25 @@ function getFields () {
  * @returns {headRef: string; headhSha: string; baseRef: string; baseSha: string; issueUrl: string; htmlUrl: string; prTitle: string; senderAvatarUrl: string; senderHtmlUrl: string;}
  */
 function getGhaEventData (eventFilePath, isGha) {
-  if (!eventFilePath || !isGha) {
-    return
-  }
+  try {
+    if (!eventFilePath || !isGha) {
+      return
+    }
 
-  const data = JSON.parse(fs.readFileSync(eventFilePath))
-  return {
-    headRef: data.pull_request.head.ref,
-    headhSha: data.pull_request.head.sha,
-    baseRef: data.pull_request.base.ref,
-    baseSha: data.pull_request.base.sha,
-    issueUrl: data.pull_request.issue_url,
-    htmlUrl: data.pull_request.html_url,
-    prTitle: data.pull_request.title,
-    senderAvatarUrl: data.sender.avatar_url,
-    senderHtmlUrl: data.sender.html_url
+    const data = JSON.parse(fs.readFileSync(eventFilePath))
+    return {
+      headRef: data.pull_request.head.ref,
+      headhSha: data.pull_request.head.sha,
+      baseRef: data.pull_request.base.ref,
+      baseSha: data.pull_request.base.sha,
+      issueUrl: data.pull_request.issue_url,
+      htmlUrl: data.pull_request.html_url,
+      prTitle: data.pull_request.title,
+      senderAvatarUrl: data.sender.avatar_url,
+      senderHtmlUrl: data.sender.html_url
+    }
+  } catch (e) {
+    console.debug('[GHA Data Error]: ', e)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ function getFields () {
  */
 function getGhaEventData (eventFilePath, isGha) {
   try {
-    if (!eventFilePath || !isGha) {
+    if (!eventFilePath || isGha !== 'true') {
       return
     }
 


### PR DESCRIPTION
We need to get information about event data file when the git info is gathered in a GitHub actions environment.
A new property is added in the commit info function called `ghaEventData` that contains the previously mentioned information:

```
{
    headRef: 'commit-info-branch',
    headhSha: '0cad5944f0b6dfa94cec2afd3366bb6a93131beb',
    baseRef: 'main',
    baseSha: '1822449d2b96f901312748e518ba129a22e9ae69',
    issueUrl: 'https://api.github.com/repos/miguelangarano/currents-playwright-ex/issues/1',
    htmlUrl: 'https://github.com/miguelangarano/currents-playwright-ex/pull/1',
    prTitle: 'test',
    senderAvatarUrl: 'https://avatars.githubusercontent.com/u/26367577?v=4',
    senderHtmlUrl: 'https://github.com/miguelangarano'
  }
```

This image refers to a screenshot of a GitHub action executed with the new implementation.

![image](https://github.com/currents-dev/commit-info/assets/140348970/ab542852-05c3-4625-87d9-3eef51b54000)
